### PR TITLE
Enclaves ci

### DIFF
--- a/pkg/dispers/conceptindexor.go
+++ b/pkg/dispers/conceptindexor.go
@@ -2,13 +2,24 @@ package enclave
 
 import (
 	"errors"
-	"strings"
+
+	"golang.org/x/crypto/scrypt"
 
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
+
+const defaultN = 32768
+const defaultR = 8
+const defaultP = 1
+
+// hash length
+const defaultDkLen = 32
+
+// salt length
+var defaultSalt = "CozyCloud"
 
 /*
 ConceptDoc is used to save a concept's salt into Concept Indexor's database
@@ -32,7 +43,7 @@ func (t *ConceptDoc) Rev() string {
 
 // DocType is used to get DocType
 func (t *ConceptDoc) DocType() string {
-	return "io.cozy.hashconcept"
+	return "io.cozy.Hashconcept"
 }
 
 // Clone is used to create another ConceptDoc from this ConceptDoc
@@ -51,7 +62,8 @@ func (t *ConceptDoc) SetRev(rev string) {
 	t.ConceptRev = rev
 }
 
-func addSalt(concept string) error {
+// AddSalt does not check is one salt is already existing
+func AddSalt(concept string) error {
 
 	ConceptDoc := &ConceptDoc{
 		ConceptID:  "",
@@ -63,17 +75,17 @@ func addSalt(concept string) error {
 	return couchdb.CreateDoc(prefixer.ConceptIndexorPrefixer, ConceptDoc)
 }
 
-func getSalt(concept string) (string, error) {
+func GetSalt(concept string) (string, error) {
 
 	salt := ""
-	err := couchdb.DefineIndex(prefixer.ConceptIndexorPrefixer, mango.IndexOnFields("io.cozy.hashconcept", "concept-index", []string{"concept"}))
+	err := couchdb.DefineIndex(prefixer.ConceptIndexorPrefixer, mango.IndexOnFields("io.cozy.Hashconcept", "concept-index", []string{"concept"}))
 	if err != nil {
 		return salt, err
 	}
 
 	var out []ConceptDoc
 	req := &couchdb.FindRequest{Selector: mango.Equal("concept", concept)}
-	err = couchdb.FindDocs(prefixer.ConceptIndexorPrefixer, "io.cozy.hashconcept", req, out)
+	err = couchdb.FindDocs(prefixer.ConceptIndexorPrefixer, "io.cozy.Hashconcept", req, &out)
 	if err != nil {
 		return salt, err
 	}
@@ -91,21 +103,32 @@ func getSalt(concept string) (string, error) {
 }
 
 // TODO: Implements bcrypt or argon instead of scrypt
-func hash(str string) (string, error) {
+func Hash(str string, saltIn string) (string, error) {
 
-	scrypt, err := crypto.GenerateFromPassphrase([]byte(str))
+	salt := saltIn
+	if saltIn == "" {
+		salt = defaultSalt
+	}
+
+	// scrypt the cleartext passphrase with the same parameters
+	other, err := scrypt.Key([]byte(str), []byte(salt), defaultN, defaultR, defaultP, defaultDkLen)
 	if err != nil {
 		return "", err
 	}
 
-	return string(scrypt), err
+	return string(other), err
 }
 
-func isConceptExisting(concept string) (bool, error) {
+func IsConceptExisting(hashedConcept string) (bool, error) {
+
+	err := couchdb.DefineIndex(prefixer.ConceptIndexorPrefixer, mango.IndexOnFields("io.cozy.Hashconcept", "concept-index", []string{"concept"}))
+	if err != nil {
+		return false, err
+	}
 
 	var out []ConceptDoc
-	req := &couchdb.FindRequest{Selector: mango.Equal("concept", concept)}
-	err := couchdb.FindDocs(prefixer.ConceptIndexorPrefixer, "io.cozy.hashconcept", req, out)
+	req := &couchdb.FindRequest{Selector: mango.Equal("concept", hashedConcept)}
+	err = couchdb.FindDocs(prefixer.ConceptIndexorPrefixer, "io.cozy.Hashconcept", req, &out)
 	if err != nil {
 		return false, err
 	}
@@ -126,10 +149,15 @@ func DeleteConcept(encryptedConcept string) error {
 	// TODO: Decrypte concept with private key
 	concept := encryptedConcept
 
-	// TODO: Delete document in database
+	hashedConcept, err := Hash(concept, "")
+	if err != nil {
+		return err
+	}
+
+	// Delete document in database
 	var out []ConceptDoc
-	req := &couchdb.FindRequest{Selector: mango.Equal("concept", concept)}
-	err := couchdb.FindDocs(prefixer.ConceptIndexorPrefixer, "io.cozy.hashconcept", req, out)
+	req := &couchdb.FindRequest{Selector: mango.Equal("concept", hashedConcept)}
+	err = couchdb.FindDocs(prefixer.ConceptIndexorPrefixer, "io.cozy.Hashconcept", req, &out)
 	if err != nil {
 		return err
 	}
@@ -154,12 +182,18 @@ HashMeThat is used to get a concept's salt. If the salt is absent from CI databa
 the function creates the salt and notify the user that the salt has just been created
 */
 func HashMeThat(encryptedConcept string) (string, error) {
-	couchdb.EnsureDBExist(prefixer.ConceptIndexorPrefixer, "io.cozy.hashconcept")
+	couchdb.EnsureDBExist(prefixer.ConceptIndexorPrefixer, "io.cozy.Hashconcept")
 
 	// TODO: Decrypte concept with private key
 	concept := encryptedConcept
 
-	isExisting, err := isConceptExisting(concept)
+	// Get salt with Hash(concept)
+	hashedConcept, err := Hash(concept, "")
+	if err != nil {
+		return "", err
+	}
+
+	isExisting, err := IsConceptExisting(hashedConcept)
 	if err != nil {
 		return "", err
 	}
@@ -167,25 +201,20 @@ func HashMeThat(encryptedConcept string) (string, error) {
 	if isExisting {
 		// Write in Metadata that concept has been retrieved
 	} else {
-		err = addSalt(concept)
+		err = AddSalt(hashedConcept)
 		if err != nil {
 			return "", err
 		}
 		// Write in Metadata that concept has been created
 	}
 
-	// Get salt with hash(concept)
-	hashedConcept, err := hash(concept)
-	if err != nil {
-		return "", err
-	}
-	salt, err := getSalt(hashedConcept)
+	salt, err := GetSalt(hashedConcept)
 	if err != nil {
 		return "", err
 	}
 
-	// Merge concept and salt, then hash
-	justHashed, err := hash(strings.Join([]string{concept, salt}, ""))
+	// Merge concept and salt, then Hash
+	justHashed, err := Hash(concept, salt)
 
 	return justHashed, err
 }

--- a/pkg/dispers/conceptindexor.go
+++ b/pkg/dispers/conceptindexor.go
@@ -1,15 +1,19 @@
 package enclave
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
-	"github.com/cozy/echo"
-	//"github.com/cozy/cozy-stack/pkg/crypto" utils -> fct to generate random bytes
 )
 
 type conceptDoc struct {
-	conceptID  string `json:"_id,omitempty"` // ID = hash(concept)
+	conceptID  string `json:"_id,omitempty"`
 	conceptRev string `json:"_rev,omitempty"`
+	concept    string `json:"concept,omitempty"`
 	salt       string `json:"salt,omitempty"`
 }
 
@@ -38,43 +42,130 @@ func (t *conceptDoc) SetRev(rev string) {
 	t.conceptRev = rev
 }
 
-func hash(concept string, salt string) string {
-	return concept + "54g5fe45zgr1nefeyf4e5"
-}
+func addSalt(concept string) error {
 
-// Randomly generate a salt
-func generatesalt() string {
-	return "TODOTODO5d4g4r8g4r4gr"
-}
-
-func HashMeThat(concept string) echo.Map {
-
-	// TODO : Decrypte concept with private key
-	// TODO : get salt with hash(concept)
-	salt := "hey"
-
-	return echo.Map{
-		"ok":      true,
-		"concept": concept, // La valeur pourra être chiffrée
-		"hash":    hash(concept, salt),
-		"meta":    "TODO",
-	}
-}
-
-func AddConcept(concept string) echo.Map {
-
-	couchdb.EnsureDBExist(prefixer.ConceptIndexorPrefixer, "io.cozy.hashconcept")
 	conceptDoc := &conceptDoc{
 		conceptID:  "",
 		conceptRev: "",
-		salt:       generatesalt(),
+		concept:    concept,
+		salt:       string(crypto.GenerateRandomBytes(5)),
 	}
 
-	// TODO : Change to create doc with hash(concept) as doc ID
-	err := couchdb.CreateDoc(prefixer.ConceptIndexorPrefixer, conceptDoc)
+	return couchdb.CreateDoc(prefixer.ConceptIndexorPrefixer, conceptDoc)
+}
 
-	return echo.Map{
-		"ok":      err == nil,
-		"message": err,
+func getSalt(concept string) (string, error) {
+
+	salt := ""
+	err := couchdb.DefineIndex(prefixer.ConceptIndexorPrefixer, mango.IndexOnFields("io.cozy.hashconcept", "concept-index", []string{"concept"}))
+	if err != nil {
+		return salt, err
 	}
+
+	var out []conceptDoc
+	req := &couchdb.FindRequest{Selector: mango.Equal("concept", concept)}
+	err = couchdb.FindDocs(prefixer.ConceptIndexorPrefixer, "io.cozy.hashconcept", req, out)
+	if err != nil {
+		return salt, err
+	}
+
+	if len(out) == 1 {
+		salt = out[0].salt
+	} else if len(out) == 0 {
+		// TODO: Creation an error
+		errors.New("Concept Indexor : no existing salt for this concept")
+	} else {
+		errors.New("Concept Indexor : several salts for this concept")
+	}
+
+	return salt, err
+}
+
+func hash(str string) string {
+	return ""
+}
+
+func isConceptExisting(concept string) (bool, error) {
+
+	var out []conceptDoc
+	req := &couchdb.FindRequest{Selector: mango.Equal("concept", concept)}
+	err := couchdb.FindDocs(prefixer.ConceptIndexorPrefixer, "io.cozy.hashconcept", req, out)
+	if err != nil {
+		return false, err
+	}
+
+	if len(out) > 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+/*
+DeleteConcept is used to delete a salt in ConceptIndexor Database. It has to be
+used to update a salt.
+*/
+func DeleteConcept(encryptedConcept string) error {
+
+	// TODO: Decrypte concept with private key
+	concept := encryptedConcept
+
+	// TODO: Delete document in database
+	var out []conceptDoc
+	req := &couchdb.FindRequest{Selector: mango.Equal("concept", concept)}
+	err := couchdb.FindDocs(prefixer.ConceptIndexorPrefixer, "io.cozy.hashconcept", req, out)
+	if err != nil {
+		return err
+	}
+
+	if len(out) == 0 {
+		return errors.New("No concept to delete")
+	}
+
+	// Delete every doc that match concept
+	for _, element := range out {
+		err = couchdb.DeleteDoc(prefixer.ConceptIndexorPrefixer, &element)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+/*
+HashMeThat is used to get a concept's salt. If the salt is absent from CI database
+the function creates the salt and notify the user that the salt has just been created
+*/
+func HashMeThat(encryptedConcept string) (string, error) {
+	couchdb.EnsureDBExist(prefixer.ConceptIndexorPrefixer, "io.cozy.hashconcept")
+
+	// TODO: Decrypte concept with private key
+	concept := encryptedConcept
+
+	isExisting, err := isConceptExisting(concept)
+	if err != nil {
+		return "", err
+	}
+
+	if isExisting {
+		// Write in Metadata that concept has been retrieved
+	} else {
+		err = addSalt(concept)
+		if err != nil {
+			return "", err
+		}
+		// Write in Metadata that concept has been created
+	}
+
+	// Get salt with hash(concept)
+	salt, err := getSalt(hash(concept))
+	if err != nil {
+		return "", err
+	}
+
+	// Merge concept and salt
+	justHashed := hash(strings.Join([]string{concept, salt}, ""))
+
+	return justHashed, nil
 }

--- a/pkg/dispers/conceptindexor_test.go
+++ b/pkg/dispers/conceptindexor_test.go
@@ -65,7 +65,6 @@ func TestConceptIndexor(t *testing.T) {
 
 }
 
-
 func TestAddSalt(t *testing.T) {
 	conceptTestRandom := string(crypto.GenerateRandomBytes(50))
 	errAdd := AddSalt(conceptTestRandom)
@@ -74,8 +73,8 @@ func TestAddSalt(t *testing.T) {
 
 func TestDeleteSalt(t *testing.T) {
 	conceptTestRandom := string(crypto.GenerateRandomBytes(50))
-	HashMeThat(conceptTestRandom)
-	err := DeleteConcept(conceptTestRandom)
+	AddSalt(conceptTestRandom)
+	err := DeleteSalt(conceptTestRandom)
 	assert.NoError(t, err)
 }
 
@@ -87,26 +86,35 @@ func TestGetSalt(t *testing.T) {
 }
 
 func TestHash(t *testing.T) {
-  	conceptTestRandom := string(crypto.GenerateRandomBytes(10))
-    res, err := Hash(conceptTestRandom, "")
-    assert.NoError(t, err)
-    res2, _ := Hash(conceptTestRandom, "")
-    assert.Equal(t, res, res2)
+	conceptTestRandom := string(crypto.GenerateRandomBytes(10))
+  res, err := Hash(conceptTestRandom, "")
+  assert.NoError(t, err)
+  res2, _ := Hash(conceptTestRandom, "")
+  assert.Equal(t, res, res2)
 }
 
 func TestHashMeThat(t *testing.T) {
-  	conceptTestRandom := string(crypto.GenerateRandomBytes(10))
-    res, err := HashMeThat(conceptTestRandom)
-    assert.NoError(t, err)
-    res2, _ := HashMeThat(conceptTestRandom)
-    assert.Equal(t, res, res2)
+	conceptTestRandom := string(crypto.GenerateRandomBytes(10))
+  res, err := HashMeThat(conceptTestRandom)
+  assert.NoError(t, err)
+  res2, _ := HashMeThat(conceptTestRandom)
+  assert.Equal(t, res, res2)
+}
+
+func TestHashIsNotDeterministic(t *testing.T) {
+	conceptTestRandom := string(crypto.GenerateRandomBytes(10))
+	hash1, _ := HashMeThat(conceptTestRandom)
+	DeleteConcept(conceptTestRandom)
+	hash2, _ := HashMeThat(conceptTestRandom)
+	DeleteConcept(conceptTestRandom)
+	assert.NotEqual(t, hash1, hash2)
 }
 
 func TestIsExistantSaltExisting(t *testing.T) {
 	conceptTestRandom := string(crypto.GenerateRandomBytes(50))
 	AddSalt(conceptTestRandom)
 	_, err := IsConceptExisting(conceptTestRandom)
-		assert.NoError(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIsUnexistantSaltExisting(t *testing.T) {

--- a/pkg/dispers/conceptindexor_test.go
+++ b/pkg/dispers/conceptindexor_test.go
@@ -1,1 +1,33 @@
 package enclave
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConceptIndexor(t *testing.T) {
+	// Generate fake concept
+
+	// Test if concept exist
+
+	// Create new conceptDoc with getHashConcept
+
+	// Test if concept exist
+
+	// getHashConcept
+
+	// deleteConcept
+
+	// Test if concept exist
+
+	assert.Equal(t, "foo", "fooo")
+}
+
+func TestDeleteConcept(t *testing.T) {
+	assert.Equal(t, "foo", "fooo")
+}
+
+func TestHashMeThat(t *testing.T) {
+	assert.Equal(t, "foo", "fooo")
+}

--- a/pkg/dispers/conceptindexor_test.go
+++ b/pkg/dispers/conceptindexor_test.go
@@ -3,31 +3,114 @@ package enclave
 import (
 	"testing"
 
+	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConceptIndexor(t *testing.T) {
+
 	// Generate fake concept
+	conceptTest := "FrançoisEtPaul"
+	conceptTestRandom := string(crypto.GenerateRandomBytes(50))
 
-	// Test if concept exist
+	// Test if concept exist (conceptTestRandom is supposed to be new)
+	b, err := IsConceptExisting(conceptTestRandom)
+	assert.NoError(t, err)
+	assert.Equal(t, b, false)
 
-	// Create new conceptDoc with getHashConcept
+	// Create new conceptDoc with HashMeThat
+	hashed, err := HashMeThat(conceptTest)
+	_, errb := HashMeThat(conceptTestRandom)
+	assert.NoError(t, err)
+	assert.NoError(t, errb)
 
-	// Test if concept exist
+	// Test if concept exist using Hash and IsConceptExisting
+	hashedConceptTest, err := Hash(conceptTest, "")
+	hashedConceptRandom, err2 := Hash(conceptTestRandom, "")
+	assert.NoError(t, err)
+	assert.NoError(t, err2)
+	a, err2 := IsConceptExisting(hashedConceptTest)
+	b2, errb := IsConceptExisting(hashedConceptRandom)
+	assert.NoError(t, err2)
+	assert.NoError(t, errb)
+	assert.Equal(t, a, true)
+	assert.Equal(t, b2, true)
 
-	// getHashConcept
+	// Check a second HashMeThat
+	hashed2, err := HashMeThat(conceptTest)
+	assert.NoError(t, err)
+	assert.Equal(t, hashed, hashed2)
+
+	// Create twice the same salt and check if there is error when getting salt
+	errAdd := AddSalt(hashedConceptTest)
+	assert.NoError(t, errAdd)
+	_, errGet := GetSalt(hashedConceptTest)
+	assert.Error(t, errGet)
+	_, errGetb := GetSalt(hashedConceptRandom)
+	assert.NoError(t, errGetb)
 
 	// deleteConcept
+	errD := DeleteConcept(conceptTest)
+	errDb := DeleteConcept(conceptTestRandom)
+	assert.NoError(t, errD)
+	assert.NoError(t, errDb)
 
 	// Test if concept exist
+	ad, err := IsConceptExisting(hashedConceptTest)
+	bd, errb := IsConceptExisting(hashedConceptRandom)
+	assert.NoError(t, err)
+	assert.NoError(t, errb)
+	assert.Equal(t, ad, false)
+	assert.Equal(t, bd, false)
 
-	assert.Equal(t, "foo", "fooo")
 }
 
-func TestDeleteConcept(t *testing.T) {
-	assert.Equal(t, "foo", "fooo")
+
+func TestAddSalt(t *testing.T) {
+	conceptTestRandom := string(crypto.GenerateRandomBytes(50))
+	errAdd := AddSalt(conceptTestRandom)
+	assert.NoError(t, errAdd)
+}
+
+func TestDeleteSalt(t *testing.T) {
+	conceptTestRandom := string(crypto.GenerateRandomBytes(50))
+	HashMeThat(conceptTestRandom)
+	err := DeleteConcept(conceptTestRandom)
+	assert.NoError(t, err)
+}
+
+func TestGetSalt(t *testing.T) {
+	conceptTestRandom := string(crypto.GenerateRandomBytes(50))
+	_ = AddSalt(conceptTestRandom)
+	_, err := GetSalt(conceptTestRandom)
+	assert.NoError(t, err)
+}
+
+func TestHash(t *testing.T) {
+  	conceptTestRandom := string(crypto.GenerateRandomBytes(10))
+    res, err := Hash(conceptTestRandom, "")
+    assert.NoError(t, err)
+    res2, _ := Hash(conceptTestRandom, "")
+    assert.Equal(t, res, res2)
 }
 
 func TestHashMeThat(t *testing.T) {
-	assert.Equal(t, "foo", "fooo")
+  	conceptTestRandom := string(crypto.GenerateRandomBytes(10))
+    res, err := HashMeThat(conceptTestRandom)
+    assert.NoError(t, err)
+    res2, _ := HashMeThat(conceptTestRandom)
+    assert.Equal(t, res, res2)
+}
+
+func TestIsExistantSaltExisting(t *testing.T) {
+	conceptTestRandom := string(crypto.GenerateRandomBytes(50))
+	AddSalt(conceptTestRandom)
+	_, err := IsConceptExisting(conceptTestRandom)
+		assert.NoError(t, err)
+}
+
+func TestIsUnexistantSaltExisting(t *testing.T) {
+	conceptTestRandom := string(crypto.GenerateRandomBytes(50))
+	_, err := IsConceptExisting(conceptTestRandom)
+	assert.NoError(t, err)
 }

--- a/pkg/dispers/conductor_test.go
+++ b/pkg/dispers/conductor_test.go
@@ -9,22 +9,27 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
+	"github.com/stretchr/testify/assert"
 )
 
 /*
 General tests on DISPERS API. HTTP requests are sent and answers are analysed.
 */
-
-/*
 func TestDecrypteConcept(t *testing.T) {
 	testCI := Actor{
 		host: "localhost:8080",
 		api:  "conceptindexor",
 	}
-	testCI.makeRequestPost("hash/concept=lib", "")
-	assert.Equal(t, "foo", testCI.outstr)
+	testCI.makeRequestPost("hash/concept=majeur", "")
+	req1 := testCI.outstr
+	testCI.makeRequestPost("hash/concept=majeur", "")
+	req2 := testCI.outstr
+	assert.Equal(t, req1, req2)
+	//testCI.makeRequestDelete("hash/concept=majeur", "")
+	//req2 := testCI.outstr
 }
 
+/*
 func TestGetTargets(t *testing.T) {
 	testTF := Actor{
 		host: "localhost:8080",

--- a/pkg/dispers/dispers_test.go
+++ b/pkg/dispers/dispers_test.go
@@ -2,18 +2,20 @@ package enclave
 
 import (
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
-	"strings"
+	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/cozy/checkup"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 /*
 General tests on DISPERS API. HTTP requests are sent and answers are analysed.
 */
 
+/*
 func TestDecrypteConcept(t *testing.T) {
 	testCI := Actor{
 		host: "localhost:8080",
@@ -69,4 +71,24 @@ func TestUpdateDoc(t *testing.T) {
 }
 
 func TestLead(t *testing.T) {
+}
+*/
+
+func TestMain(m *testing.M) {
+	config.UseTestFile()
+
+	// First we make sure couchdb is started
+	db, err := checkup.HTTPChecker{URL: config.CouchURL().String()}.Check()
+	if err != nil || db.Status() != checkup.Healthy {
+		fmt.Println("This test need couchdb to run.")
+		os.Exit(1)
+	}
+
+	couchdb.EnsureDBExist(prefixer.TestConceptIndexorPrefixer, "io.cozy.hashconcept")
+	couchdb.DeleteDB(prefixer.TestConceptIndexorPrefixer, "io.cozy.hashconcept")
+	couchdb.EnsureDBExist(prefixer.TestConceptIndexorPrefixer, "io.cozy.hashconcept")
+
+	res := m.Run()
+	os.Exit(res)
+
 }

--- a/pkg/prefixer/prefixer.go
+++ b/pkg/prefixer/prefixer.go
@@ -40,3 +40,5 @@ var TargetPrefixer = NewPrefixer("", "target")
 var TargetFinderPrefixer = NewPrefixer("", "targetfinder")
 var DataAggregatorPrefixer = NewPrefixer("", "dataaggregator")
 var ConductorPrefixer = NewPrefixer("", "conductor")
+
+var TestConceptIndexorPrefixer = NewPrefixer("", "testconceptindexor")

--- a/web/dispers/dispers.go
+++ b/web/dispers/dispers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/cozy/cozy-stack/pkg/dispers"
+	"github.com/cozy/cozy-stack/pkg/dispers/dispers"
 	"github.com/cozy/echo"
 )
 
@@ -98,9 +99,9 @@ func createTraining(c echo.Context) error {
 
 	return c.JSON(http.StatusCreated, echo.Map{
 		"ok":   true,
-		"id":   cond.querydoc.ID(),
-		"rev":  cond.querydoc.Rev(),
-		"type": cond.querydoc.DocType(),
+		"id":   cond.Doc.ID(),
+		"rev":  cond.Doc.Rev(),
+		"type": cond.Doc.DocType(),
 	})
 }
 
@@ -114,14 +115,20 @@ CONCEPT INDEXOR'S ROUTES : those functions are used on route ./dispers/conceptin
 func hashConcept(c echo.Context) error {
 
 	concept := c.Param("concept")
-	return c.JSON(http.StatusCreated, enclave.HashMeThat(concept))
+	hash, err := enclave.HashMeThat(concept)
+	return c.JSON(http.StatusCreated, echo.Map{
+		"ok":   err == nil,
+		"hash": hash,
+	})
 }
 
+/*
 func addConcept(c echo.Context) error {
 
 	concept := c.Param("concept")
 	return c.JSON(http.StatusCreated, enclave.AddConcept(concept))
 }
+*/
 
 /*
 *
@@ -132,7 +139,7 @@ TARGET FINDER'S ROUTES : those functions are used on route ./dispers/targetfinde
 */
 func selectAdresses(c echo.Context) error {
 
-	var listsOfAdresses enclave.InputTF
+	var listsOfAdresses dispers.InputTF
 
 	if err := json.NewDecoder(c.Request().Body).Decode(&listsOfAdresses); err != nil {
 		return c.JSON(http.StatusOK, echo.Map{"outcome": "error",
@@ -157,7 +164,7 @@ Target'S ROUTES : those functions are used on route ./dispers/target/
 */
 func getQueriesAndTokens(c echo.Context) error {
 
-	var localQuery enclave.InputT
+	var localQuery dispers.InputT
 
 	if err := json.NewDecoder(c.Request().Body).Decode(&localQuery); err != nil {
 		return c.JSON(http.StatusOK, echo.Map{"outcome": "error",
@@ -193,7 +200,7 @@ DATA AGGREGATOR'S ROUTES : those functions are used on route ./dispers/dataaggre
 */
 func launchAggr(c echo.Context) error {
 
-	var inputDA enclave.InputDA
+	var inputDA dispers.InputDA
 
 	if err := json.NewDecoder(c.Request().Body).Decode(&inputDA); err != nil {
 		return c.JSON(http.StatusOK, echo.Map{"outcome": "error",
@@ -231,7 +238,7 @@ func Routes(router *echo.Group) {
 
 	//router.GET("/conceptindexor/_all_concepts", allConcepts)
 	router.POST("/conceptindexor/hash/concept=:concept", hashConcept)      // used to hash a concept
-	router.POST("/conceptindexor/addconcept/concept=:concept", addConcept) // used to add a concept to his list and generate SymCk
+	//router.POST("/conceptindexor/addconcept/concept=:concept", addConcept) // used to add a concept to his list and generate SymCk
 
 	//router.POST("/targetfinder/listofadresses", insertAdress)
 	//router.DELETE("/targetfinder/listofadresses", deleteAdress)


### PR DESCRIPTION
Première implémentation de l'enclave CI et des tests associés. Un peu plus de 35% de coverage des tests. 

Choix discutable d'implémentation : 
- Les routes Ajout Concept et Hash Concept sont fusionnées. Autrement dit, si un utilisateur demande le haché d'un concept non existant, il est automatiquement créé (avec stockage dans la BDD)

TODO : 
- Route Delete Concept (pour l'instant seulement la méthode est créée, sans être reliée à une route)
- Gérer le déchiffrement du concept reçu
- Passer de scrypt à une autre méthode de hachage