### PR TITLE
Build enclave TF

### DIFF
--- a/pkg/dispers/dispers/requests.go
+++ b/pkg/dispers/dispers/requests.go
@@ -1,0 +1,175 @@
+package dispers
+
+import "errors"
+
+/*
+*
+Queries' Input & Output
+*
+*/
+
+/*
+*
+Concept Indexors' Input & Output
+*
+*/
+
+// OutputCI contains a boolean and the result
+type OutputCI struct {
+	Outcome string `json:"ok,omitempty"`
+	Hash    string `json:"hash,omitempty"`
+}
+
+/*
+*
+Target Finders' Input & Output
+*
+*/
+
+// Operation interface allows the possibility to compute targer profile in a
+// recursive way
+type Operation interface {
+	Compute(list map[string][]string) ([]string, error)
+}
+
+// Single is a leaf in target profile tree
+type Single struct {
+	Value string `json:"value,omitempty"`
+}
+
+// Compute return the list of encrypted addresses
+func (s *Single) Compute(list map[string][]string) ([]string, error) {
+	val, ok := list[s.Value]
+	if !ok {
+		return []string{}, errors.New("Unknown concept")
+	}
+	return val, nil
+}
+
+func union(a, b []string) []string {
+	m := make(map[string]bool)
+
+	for _, item := range a {
+		m[item] = true
+	}
+
+	for _, item := range b {
+		if _, ok := m[item]; !ok {
+			a = append(a, item)
+		}
+	}
+	return a
+}
+
+// Union struct compute union between to Operation
+type Union struct {
+	ValueA Operation `json:"value_a,omitempty"`
+	ValueB Operation `json:"value_b,omitempty"`
+}
+
+// Compute returns the union's result
+func (u *Union) Compute(list map[string][]string) ([]string, error) {
+	a, err := u.ValueA.Compute(list)
+	if err != nil {
+		return []string{}, err
+	}
+	b, err := u.ValueB.Compute(list)
+	if err != nil {
+		return []string{}, err
+	}
+	return union(a, b), nil
+}
+
+func intersection(a, b []string) (c []string) {
+	m := make(map[string]bool)
+
+	for _, item := range a {
+		m[item] = true
+	}
+
+	for _, item := range b {
+		if _, ok := m[item]; ok {
+			c = append(c, item)
+		}
+	}
+	return
+}
+
+// Intersection computes the intersection between two lists of addresses
+type Intersection struct {
+	ValueA Operation `json:"value_a,omitempty"`
+	ValueB Operation `json:"value_b,omitempty"`
+}
+
+// Compute returns a list of adresses
+func (i *Intersection) Compute(list map[string][]string) ([]string, error) {
+	a, err := i.ValueA.Compute(list)
+	if err != nil {
+		return []string{}, err
+	}
+	b, err := i.ValueB.Compute(list)
+	if err != nil {
+		return []string{}, err
+	}
+	return intersection(a, b), nil
+}
+
+// InputTF contains a map that associate every concept to a list of Addresses
+// and a operation to compute to retrive the final list
+type InputTF struct {
+	ListsOfAddresses map[string][]string `json:"concepts,omitempty"`
+	TargetProfile    Operation           `json:"operation,omitempty"`
+}
+
+/*
+*
+Targets' Input & Output
+*
+*/
+type InputT struct {
+	Localquery       string   `json:"localquery,omitempty"`
+	ListsOfAddresses []string `json:"Addresses,omitempty"`
+}
+
+type Query struct {
+	Query string `json:"query,omitempty"`
+	OAuth string `json:"oauth,omitempty"`
+}
+
+type OutputT struct {
+	Queries []Query `json:"queries,omitempty"`
+}
+
+/*
+*
+Stacks' Input & Output
+*
+*/
+type OutputStack struct {
+}
+
+/*
+*
+Data Aggregators' Input & Output
+*
+*/
+
+/*
+DescribeData is a struct used by DAs on different layers to communicate on the shape
+of the data they dealt with.
+*/
+type DescribeData struct {
+	Dataset         string   `json:"dataset,omitempty"`
+	Preprocess      string   `json:"preprocess,omitempty"`
+	Standardization string   `json:"standardization,omitempty"`
+	Shape           []int64  `json:"shape,omitempty"`
+	Labels          []string `json:"fakelabels,omitempty"`
+}
+
+type InputDA struct {
+	InputType DescribeData `json:"type,omitempty"`
+	InputData string       `json:"data,omitempty"`
+}
+
+type OutputDA struct {
+}

--- a/pkg/dispers/dispers/requests_test.go
+++ b/pkg/dispers/dispers/requests_test.go
@@ -1,0 +1,98 @@
+package dispers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnion(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{"abc", "bcd", "efc"}
+	m["test2"] = []string{"hihi"}
+
+	op := Union{
+		ValueA: &Single{Value: "test1"},
+		ValueB: &Single{Value: "test2"},
+	}
+
+	res, err := op.Compute(m)
+	assert.NoError(t, err)
+	assert.Equal(t, res, []string{"abc", "bcd", "efc", "hihi"})
+
+}
+
+func TestIntersection(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{"joel", "claire", "caroline", "françois"}
+	m["test2"] = []string{"paul", "claire", "françois"}
+
+	op := Intersection{
+		ValueA: &Single{Value: "test1"},
+		ValueB: &Single{Value: "test2"},
+	}
+
+	res, err := op.Compute(m)
+	assert.NoError(t, err)
+	assert.Equal(t, res, []string{"claire", "françois"})
+
+}
+
+func TestIntersectionAndUnion(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{"joel", "claire", "caroline", "françois"}
+	m["test2"] = []string{"paul", "claire", "françois"}
+	m["test3"] = []string{"paul", "claire", "françois"}
+	m["test4"] = []string{"paul", "benjamin", "florent"}
+
+	op := Union{
+		ValueA: &Intersection{
+			ValueA: &Single{Value: "test1"},
+			ValueB: &Single{Value: "test2"},
+		},
+		ValueB: &Intersection{
+			ValueA: &Single{Value: "test3"},
+			ValueB: &Single{Value: "test4"},
+		},
+	}
+
+	res, err := op.Compute(m)
+	assert.NoError(t, err)
+	assert.Equal(t, res, []string{"claire", "françois", "paul"})
+
+}
+
+func TestBlankLeaf(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{""}
+	m["test2"] = []string{"paul", "claire", "françois"}
+
+	op := Intersection{
+		ValueA: &Single{Value: "test1"},
+		ValueB: &Single{Value: "test2"},
+	}
+
+	_, err := op.Compute(m)
+	assert.NoError(t, err)
+
+}
+
+func TestUnknownConcept(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{""}
+	m["test2"] = []string{"paul", "claire", "françois"}
+
+	op := Intersection{
+		ValueA: &Single{Value: "test3"},
+		ValueB: &Single{Value: "test2"},
+	}
+
+	_, err := op.Compute(m)
+	assert.Error(t, err)
+
+}

--- a/pkg/dispers/targetfinder.go
+++ b/pkg/dispers/targetfinder.go
@@ -1,0 +1,13 @@
+package enclave
+
+import (
+	"github.com/cozy/cozy-stack/pkg/dispers/dispers"
+)
+
+// SelectAddresses apply the target profile over lists of addresses
+func SelectAddresses(in dispers.InputTF) ([]string, error) {
+
+	finalList, err := in.TargetProfile.Compute(in.ListsOfAddresses)
+	// TODO: Encrypt final list
+	return finalList, err
+}

--- a/pkg/dispers/targetfinder_test.go
+++ b/pkg/dispers/targetfinder_test.go
@@ -1,0 +1,36 @@
+package enclave
+
+import (
+	"testing"
+
+	"github.com/cozy/cozy-stack/pkg/dispers/dispers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTargetFinder(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{"joel", "claire", "caroline", "françois"}
+	m["test2"] = []string{"paul", "claire", "françois"}
+	m["test3"] = []string{"paul", "claire", "françois"}
+	m["test4"] = []string{"paul", "benjamin", "florent"}
+
+	in := dispers.InputTF{
+		ListsOfAddresses: m,
+		TargetProfile: &dispers.Union{
+			ValueA: &dispers.Intersection{
+				ValueA: &dispers.Single{Value: "test1"},
+				ValueB: &dispers.Single{Value: "test2"},
+			},
+			ValueB: &dispers.Intersection{
+				ValueA: &dispers.Single{Value: "test3"},
+				ValueB: &dispers.Single{Value: "test4"},
+			},
+		},
+	}
+
+	res, err := SelectAddresses(in)
+	assert.NoError(t, err)
+	assert.Equal(t, res, []string{"claire", "françois", "paul"})
+
+}


### PR DESCRIPTION
Target Finder takes in input :
* A Target Profile
* A Map of Addresses (PseudoConcept <-> Lists of Addresses)

This PR implements Target Profiles by defining interface Operation and structures Single, Intersection, Union. 
This PR also implements Target Finder's treatment and tests over every process : 
* 100% Coverage for targetfinder.go
* 90.6% Coverage for requests.go