### PR TITLE
Creates Target Finder's treatment

### DIFF
--- a/pkg/dispers/dispers/requests.go
+++ b/pkg/dispers/dispers/requests.go
@@ -1,0 +1,209 @@
+package dispers
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+/*
+*
+Queries' Input & Output
+*
+*/
+
+/*
+*
+Concept Indexors' Input & Output
+*
+*/
+
+type Concept struct {
+	Concept          string `json:"concept,omitempty"`
+	EncryptedConcept []byte `json:"enc_concept,omitempty"`
+	Hash             string `json:"hash,omitempty"`
+}
+
+type InputCI struct {
+	Concepts    []Concept `json:"concepts,omitempty"`
+	IsEncrypted bool      `json:"encrypted,omitempty"`
+}
+
+// OutputCI contains a bool and the result
+type OutputCI struct {
+	Hashes []Concept `json:"hashes,omitempty"`
+}
+
+/*
+*
+Target Finders' Input & Output
+*
+*/
+
+func union(a, b []string) []string {
+	m := make(map[string]bool)
+
+	for _, item := range a {
+		m[item] = true
+	}
+
+	for _, item := range b {
+		if _, ok := m[item]; !ok {
+			a = append(a, item)
+		}
+	}
+	return a
+}
+
+func intersection(a, b []string) (c []string) {
+	m := make(map[string]bool)
+
+	for _, item := range a {
+		m[item] = true
+	}
+
+	for _, item := range b {
+		if _, ok := m[item]; ok {
+			c = append(c, item)
+		}
+	}
+	return
+}
+
+// NodeType are the only possible nodes in Target Profile trees
+type NodeType int
+
+const (
+	// SingleNode are Target Profile's leafs
+	SingleNode NodeType = iota
+	// UnionNode are unions between two lists
+	UnionNode
+	// IntersectionNode are intersections between two lists
+	IntersectionNode
+)
+
+// OperationTree allows the possibility to compute target profiles in a
+// recursive way. OperationTree contains SingleNode, UnionNode, IntersectionNode
+// SingleNodes have got a value field. A value is the name of a list of strings
+// To compute the OperationTree, Compute method needs a map that matches names
+// with list of encrypted addresses.
+type OperationTree struct {
+	Type      NodeType    `json:"type"`
+	Value     string      `json:"value,omitempty"`
+	LeftNode  interface{} `json:"left_node,omitempty"`
+	RightNode interface{} `json:"right_node,omitempty"`
+}
+
+// Compute compute the OperationTree and returns the list of encrypted addresses
+func (o *OperationTree) Compute(listsOfAddresses map[string][]string) ([]string, error) {
+
+	if o.Type == SingleNode {
+		// Retrieve list of addresses from listsOfAddresses
+		val, ok := listsOfAddresses[o.Value]
+		if !ok {
+			return []string{}, errors.New("Unknown concept")
+		}
+		return val, nil
+
+	} else if o.Type == UnionNode || o.Type == IntersectionNode {
+
+		// Compute operations on LeftNode and RightNode
+		leftNode := o.LeftNode.(OperationTree)
+		a, err := leftNode.Compute(listsOfAddresses)
+		if err != nil {
+			return []string{}, err
+		}
+		rightNode := o.RightNode.(OperationTree)
+		b, err := rightNode.Compute(listsOfAddresses)
+		if err != nil {
+			return []string{}, err
+		}
+		// Compute operation between LeftNode and RightNode
+		switch o.Type {
+		case UnionNode:
+			return union(a, b), nil
+		case IntersectionNode:
+			return intersection(a, b), nil
+		default:
+			return []string{}, errors.New("Unknown type")
+		}
+	} else {
+		return []string{}, errors.New("Unknown type")
+	}
+}
+
+// UnmarshalJSON is used to load the OperationTree given by the Querier
+func (o *OperationTree) UnmarshalJSON(data []byte) error {
+
+	var v map[string]interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	// Retrieve the NodeType
+	if v["type"] == nil {
+		return errors.New("No type defined")
+	}
+	switch int(v["type"].(float64)) {
+	case 0:
+		o.Type = SingleNode
+	case 1:
+		o.Type = UnionNode
+	case 2:
+		o.Type = IntersectionNode
+	default:
+		return errors.New("Unknown type")
+	}
+
+	// Retrieve others attributes depending on NodeType
+	switch {
+	case o.Type == SingleNode:
+		o.Value, _ = v["value"].(string)
+	case o.Type == IntersectionNode || o.Type == UnionNode:
+		var leftNode OperationTree
+		var rightNode OperationTree
+
+		leftNodeByte, _ := json.Marshal(v["left_node"].(map[string]interface{}))
+		err := json.Unmarshal(leftNodeByte, &leftNode)
+		if err != nil {
+			return err
+		}
+
+		rightNodeByte, _ := json.Marshal(v["right_node"].(map[string]interface{}))
+		err = json.Unmarshal(rightNodeByte, &rightNode)
+		if err != nil {
+			return err
+		}
+		o.LeftNode = leftNode
+		o.RightNode = rightNode
+	default:
+	}
+	return nil
+}
+
+// InputTF contains a map that associate every concept to a list of Addresses
+// and a operation to compute to retrive the final list
+type InputTF struct {
+	IsEncrypted               bool                `json:"isencrypted,omitempty"`
+	EncryptedListsOfAddresses []byte              `json:"enc_instances,omitempty"`
+	EncryptedTargetProfile    []byte              `json:"enc_operation,omitempty"`
+	ListsOfAddresses          map[string][]string `json:"instances,omitempty"`
+	TargetProfile             OperationTree       `json:"target_profile,omitempty"`
+}
+
+// OutputTF is what Target Finder send to the conductor
+type OutputTF struct {
+	ListOfAddresses          []Instance `json:"addresses,omitempty"`
+	EncryptedListOfAddresses []byte     `json:"enc_addresses,omitempty"`
+}
+
+// Token is used to serialize the token
+type Token struct {
+	TokenBearer string `json:"bearer,omitempty"`
+}
+
+// Instance describes the location of an instance and the token it had created
+type Instance struct {
+	Host   string `json:"host,omitempty"`
+	Domain string `json:"domain,omitempty"`
+	Token  Token  `json:"token,omitempty"`
+}

--- a/pkg/dispers/dispers/requests.go
+++ b/pkg/dispers/dispers/requests.go
@@ -192,8 +192,8 @@ type InputTF struct {
 
 // OutputTF is what Target Finder send to the conductor
 type OutputTF struct {
-	ListOfAddresses          []Instance `json:"addresses,omitempty"`
-	EncryptedListOfAddresses []byte     `json:"enc_addresses,omitempty"`
+	ListOfAddresses          []string `json:"addresses,omitempty"`
+	EncryptedListOfAddresses []byte   `json:"enc_addresses,omitempty"`
 }
 
 // Token is used to serialize the token

--- a/pkg/dispers/dispers/requests_test.go
+++ b/pkg/dispers/dispers/requests_test.go
@@ -1,0 +1,133 @@
+package dispers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalUnmarshalOperationTree(t *testing.T) {
+
+	targetProfile := OperationTree{
+		Type: UnionNode,
+		LeftNode: OperationTree{
+			Type:      IntersectionNode,
+			LeftNode:  OperationTree{Type: SingleNode, Value: "test1"},
+			RightNode: OperationTree{Type: SingleNode, Value: "test2"},
+		},
+		RightNode: OperationTree{
+			Type:      IntersectionNode,
+			LeftNode:  OperationTree{Type: SingleNode, Value: "test3"},
+			RightNode: OperationTree{Type: SingleNode, Value: "test4"},
+		},
+	}
+
+	encrypted, err := json.Marshal(targetProfile)
+	assert.Equal(t, "{\"type\":1,\"left_node\":{\"type\":2,\"left_node\":{\"type\":0,\"value\":\"test1\"},\"right_node\":{\"type\":0,\"value\":\"test2\"}},\"right_node\":{\"type\":2,\"left_node\":{\"type\":0,\"value\":\"test3\"},\"right_node\":{\"type\":0,\"value\":\"test4\"}}}", string(encrypted))
+	assert.NoError(t, err)
+
+	var objMap OperationTree
+	err = json.Unmarshal(encrypted, &objMap)
+	assert.NoError(t, err)
+	assert.Equal(t, targetProfile, objMap)
+
+}
+
+func TestUnion(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{"abc", "bcd", "efc"}
+	m["test2"] = []string{"hihi"}
+
+	op := OperationTree{
+		Type:      UnionNode,
+		LeftNode:  OperationTree{Type: SingleNode, Value: "test1"},
+		RightNode: OperationTree{Type: SingleNode, Value: "test2"},
+	}
+
+	res, err := op.Compute(m)
+	assert.NoError(t, err)
+	assert.Equal(t, res, []string{"abc", "bcd", "efc", "hihi"})
+
+}
+
+func TestIntersection(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{"joel", "claire", "caroline", "françois"}
+	m["test2"] = []string{"paul", "claire", "françois"}
+
+	op := OperationTree{
+		Type:      IntersectionNode,
+		LeftNode:  OperationTree{Type: SingleNode, Value: "test1"},
+		RightNode: OperationTree{Type: SingleNode, Value: "test2"},
+	}
+
+	res, err := op.Compute(m)
+	assert.NoError(t, err)
+	assert.Equal(t, res, []string{"claire", "françois"})
+
+}
+
+func TestIntersectionAndUnion(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{"joel", "claire", "caroline", "françois"}
+	m["test2"] = []string{"paul", "claire", "françois"}
+	m["test3"] = []string{"paul", "claire", "françois"}
+	m["test4"] = []string{"paul", "benjamin", "florent"}
+
+	op := OperationTree{
+		Type: UnionNode,
+		LeftNode: OperationTree{
+			Type:      IntersectionNode,
+			LeftNode:  OperationTree{Type: SingleNode, Value: "test1"},
+			RightNode: OperationTree{Type: SingleNode, Value: "test2"},
+		},
+		RightNode: OperationTree{
+			Type:      IntersectionNode,
+			LeftNode:  OperationTree{Type: SingleNode, Value: "test3"},
+			RightNode: OperationTree{Type: SingleNode, Value: "test4"},
+		},
+	}
+
+	res, err := op.Compute(m)
+	assert.NoError(t, err)
+	assert.Equal(t, res, []string{"claire", "françois", "paul"})
+
+}
+
+func TestBlankLeaf(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{""}
+	m["test2"] = []string{"paul", "claire", "françois"}
+
+	op := OperationTree{
+		Type:      IntersectionNode,
+		LeftNode:  OperationTree{Type: SingleNode, Value: "test1"},
+		RightNode: OperationTree{Type: SingleNode, Value: "test2"},
+	}
+
+	_, err := op.Compute(m)
+	assert.NoError(t, err)
+
+}
+
+func TestUnknownConcept(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{""}
+	m["test2"] = []string{"paul", "claire", "françois"}
+
+	op := OperationTree{
+		Type:      IntersectionNode,
+		LeftNode:  OperationTree{Type: SingleNode, Value: "test3"},
+		RightNode: OperationTree{Type: SingleNode, Value: "test2"},
+	}
+
+	_, err := op.Compute(m)
+	assert.Error(t, err)
+
+}

--- a/pkg/dispers/dispers_test.go
+++ b/pkg/dispers/dispers_test.go
@@ -1,0 +1,31 @@
+package enclave
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cozy/checkup"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+)
+
+func TestMain(m *testing.M) {
+	config.UseTestFile()
+
+	// First we make sure couchdb is started
+	db, err := checkup.HTTPChecker{URL: config.CouchURL().String()}.Check()
+	if err != nil || db.Status() != checkup.Healthy {
+		fmt.Println("This test need couchdb to run.")
+		os.Exit(1)
+	}
+
+	if err := couchdb.InitGlobalDB(); err != nil {
+		fmt.Println("Cant init GlobalDB")
+		os.Exit(1)
+	}
+
+	res := m.Run()
+	os.Exit(res)
+
+}

--- a/pkg/dispers/targetfinder.go
+++ b/pkg/dispers/targetfinder.go
@@ -1,0 +1,27 @@
+package enclave
+
+import (
+	"github.com/cozy/cozy-stack/pkg/dispers/dispers"
+)
+
+func decryptInputsTF(in *dispers.InputTF) error {
+
+	if in.IsEncrypted {
+		// TODO: decrypt input byte and save it in in.ListsOfAddresses
+	}
+
+	return nil
+}
+
+// SelectAddresses apply the target profile over lists of addresses
+func SelectAddresses(in dispers.InputTF) ([]string, error) {
+
+	if err := decryptInputsTF(&in); err != nil {
+		return []string{}, err
+	}
+
+	finalList, err := in.TargetProfile.Compute(in.ListsOfAddresses)
+	// TODO: Encrypt final list
+	return finalList, err
+
+}

--- a/pkg/dispers/targetfinder_test.go
+++ b/pkg/dispers/targetfinder_test.go
@@ -1,0 +1,144 @@
+package enclave
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cozy/cozy-stack/pkg/dispers/dispers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalUnmarshalNil(t *testing.T) {
+
+	targetProfile := dispers.OperationTree{}
+
+	encrypted, err := json.Marshal(targetProfile)
+	assert.NoError(t, err)
+
+	var decrypted dispers.OperationTree
+	err = json.Unmarshal(encrypted, &decrypted)
+	assert.NoError(t, err)
+
+}
+
+func TestMarshalUnmarshalOperationTree(t *testing.T) {
+
+	targetProfile := dispers.OperationTree{
+		Type: dispers.UnionNode,
+		LeftNode: dispers.OperationTree{
+			Type:      dispers.IntersectionNode,
+			LeftNode:  dispers.OperationTree{Type: dispers.SingleNode, Value: "test1"},
+			RightNode: dispers.OperationTree{Type: dispers.SingleNode, Value: "test2"},
+		},
+		RightNode: dispers.OperationTree{
+			Type:      dispers.IntersectionNode,
+			LeftNode:  dispers.OperationTree{Type: dispers.SingleNode, Value: "test3"},
+			RightNode: dispers.OperationTree{Type: dispers.SingleNode, Value: "test4"},
+		},
+	}
+
+	encrypted, err := json.Marshal(targetProfile)
+	assert.Equal(t, "{\"type\":1,\"left_node\":{\"type\":2,\"left_node\":{\"type\":0,\"value\":\"test1\"},\"right_node\":{\"type\":0,\"value\":\"test2\"}},\"right_node\":{\"type\":2,\"left_node\":{\"type\":0,\"value\":\"test3\"},\"right_node\":{\"type\":0,\"value\":\"test4\"}}}", string(encrypted))
+	assert.NoError(t, err)
+
+	var decrypted dispers.OperationTree
+	err = json.Unmarshal(encrypted, &decrypted)
+	assert.NoError(t, err)
+	assert.Equal(t, targetProfile, decrypted)
+
+}
+
+func TestTargetFinder(t *testing.T) {
+
+	m := make(map[string][]string)
+	m["test1"] = []string{"joel", "claire", "caroline", "françois"}
+	m["test2"] = []string{"paul", "claire", "françois"}
+	m["test3"] = []string{"paul", "claire", "françois"}
+	m["test4"] = []string{"paul", "benjamin", "florent"}
+
+	targetProfile := dispers.OperationTree{
+		Type: dispers.UnionNode,
+		LeftNode: dispers.OperationTree{
+			Type:      dispers.IntersectionNode,
+			LeftNode:  dispers.OperationTree{Type: dispers.SingleNode, Value: "test1"},
+			RightNode: dispers.OperationTree{Type: dispers.SingleNode, Value: "test2"},
+		},
+		RightNode: dispers.OperationTree{
+			Type:      dispers.IntersectionNode,
+			LeftNode:  dispers.OperationTree{Type: dispers.SingleNode, Value: "test3"},
+			RightNode: dispers.OperationTree{Type: dispers.SingleNode, Value: "test4"},
+		},
+	}
+
+	in := dispers.InputTF{
+		IsEncrypted:      false,
+		ListsOfAddresses: m,
+		TargetProfile:    targetProfile,
+	}
+
+	out, err := SelectAddresses(in)
+	assert.NoError(t, err)
+	assert.Equal(t, out, []string{"claire", "françois", "paul"})
+
+	targetProfile = dispers.OperationTree{
+		Type: dispers.IntersectionNode,
+		LeftNode: dispers.OperationTree{
+			Type:      dispers.UnionNode,
+			LeftNode:  dispers.OperationTree{Type: dispers.SingleNode, Value: "test1"},
+			RightNode: dispers.OperationTree{Type: dispers.SingleNode, Value: "test2"},
+		},
+		RightNode: dispers.OperationTree{
+			Type:      dispers.UnionNode,
+			LeftNode:  dispers.OperationTree{Type: dispers.SingleNode, Value: "test3"},
+			RightNode: dispers.OperationTree{Type: dispers.SingleNode, Value: "test7"},
+		},
+	}
+
+	in = dispers.InputTF{
+		IsEncrypted:      false,
+		ListsOfAddresses: m,
+		TargetProfile:    targetProfile,
+	}
+
+	_, err = SelectAddresses(in)
+	assert.Error(t, err)
+
+	// Union between Single and Intersection
+	targetProfile = dispers.OperationTree{
+		Type: dispers.IntersectionNode,
+		LeftNode: dispers.OperationTree{
+			Type:      dispers.UnionNode,
+			LeftNode:  dispers.OperationTree{Type: dispers.SingleNode, Value: "test1"},
+			RightNode: dispers.OperationTree{Type: dispers.SingleNode, Value: "test2"},
+		},
+		RightNode: dispers.OperationTree{Type: dispers.SingleNode, Value: "test4"},
+	}
+
+	in = dispers.InputTF{
+		IsEncrypted:      false,
+		ListsOfAddresses: m,
+		TargetProfile:    targetProfile,
+	}
+
+	out, err = SelectAddresses(in)
+	assert.NoError(t, err)
+	assert.Equal(t, out, []string{"paul"})
+
+	// No type precised
+	targetProfile = dispers.OperationTree{
+		LeftNode: dispers.OperationTree{
+			LeftNode:  dispers.OperationTree{Value: "test1"},
+			RightNode: dispers.OperationTree{Value: "test2"},
+		},
+		RightNode: dispers.OperationTree{Value: "test4"},
+	}
+
+	in = dispers.InputTF{
+		IsEncrypted:      false,
+		ListsOfAddresses: m,
+		TargetProfile:    targetProfile,
+	}
+
+	_, err = SelectAddresses(in)
+	assert.Error(t, err)
+}

--- a/web/dispers/dispers.go
+++ b/web/dispers/dispers.go
@@ -1,0 +1,90 @@
+package dispers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/cozy/cozy-stack/pkg/dispers"
+	"github.com/cozy/cozy-stack/pkg/dispers/dispers"
+	"github.com/cozy/echo"
+)
+
+/*
+*
+CONCEPT INDEXOR'S ROUTES : those functions are used on route ./dispers/conceptindexor/
+*
+*
+*/
+
+func createConcept(c echo.Context) error {
+
+	// Get concept from body
+	var in dispers.InputCI
+	if err := json.NewDecoder(c.Request().Body).Decode(&in); err != nil {
+		return err
+	}
+
+	// Create array of hashes
+	hashes := make([]string, len(in.EncryptedConcepts))
+	var sliceOfMeta []metadata.Metadata
+	for index, element := range in.EncryptedConcepts {
+		meta := metadata.NewMetadata("Hash concept", strings.Join([]string{in.EncryptedConcepts, in.Concepts}, ""), []string{"CI", "Concept"})
+		out, err := enclave.CreateConcept(element)
+		if err != nil {
+			return err
+		}
+		meta.Close(out, err)
+		hashes[index] = out
+		sliceOfMeta = append(sliceOfMeta, meta)
+	}
+	return c.JSON(http.StatusOK, dispers.OutputCI{
+		Hashes:            hashes,
+		metadata.Metadata: sliceOfMeta,
+	})
+}
+
+func deleteConcept(c echo.Context) error {
+	concept := c.Param("concept")
+
+	err := enclave.DeleteConcept([]byte(concept))
+	if err != nil {
+		return err
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+/*
+*
+*
+TARGET FINDER'S ROUTES : those functions are used on route ./dispers/targetfinder/
+*
+*
+*/
+func selectAddresses(c echo.Context) error {
+
+	var inputTF dispers.InputTF
+	if err := json.NewDecoder(c.Request().Body).Decode(&inputTF); err != nil {
+		return err
+	}
+
+	finallist, err := enclave.SelectAddresses(inputTF)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, dispers.OutputTF{
+		ListOfAddresses: finallist,
+	})
+}
+
+// Routes sets the routing for the dispers service
+func Routes(router *echo.Group) {
+
+	// TODO : Create a route to retrieve public key
+	router.POST("/conceptindexor/concept", createConcept)            // hash a concept (and save the salt if needed)
+	router.DELETE("/conceptindexor/concept/:concept", deleteConcept) // delete a salt in the database
+
+	router.POST("/targetfinder/addresses", selectAddresses)
+
+}


### PR DESCRIPTION
Target Finder takes in input :
* A Target Profile
* A Map of Addresses (PseudoConcept <-> Lists of Addresses)

This PR implements Target Profiles by defining interface Operation and structures Single, Intersection, Union. 
This PR also implements Target Finder's treatment and tests over every process 