### PR TITLE
Build metadata

### DIFF
--- a/pkg/couchdb/index.go
+++ b/pkg/couchdb/index.go
@@ -54,6 +54,8 @@ var secretIndexes = []*mango.Index{
 	mango.IndexOnFields(consts.AccountTypes, "by-slug", []string{"slug"}),
 }
 
+var metadataIndexes = []*mango.Index{mango.IndexOnFields("io.cozy.execution.metadata", "metadata-index", []string{"query"})}
+
 // DomainAndAliasesView defines a view to fetch instances by domain and domain
 // aliases.
 var DomainAndAliasesView = &View{
@@ -89,7 +91,25 @@ func InitGlobalDB() error {
 	if err := DefineIndexes(prefixer.ConceptIndexorPrefixer, conceptIndexorIndexes); err != nil {
 		return err
 	}
+	if err := DefineIndexes(prefixer.ConductorPrefixer, metadataIndexes); err != nil {
+		return err
+	}
+	return DefineViews(GlobalDB, globalViews)
+}
+
+// InitGlobalTestDB defines views and indexes on the global databases. It is called
+// on every startup of the stack.
+func InitGlobalTestDB() error {
+	if err := DefineIndexes(GlobalSecretsDB, secretIndexes); err != nil {
+		return err
+	}
+	if err := DefineIndexes(GlobalDB, globalIndexes); err != nil {
+		return err
+	}
 	if err := DefineIndexes(prefixer.TestConceptIndexorPrefixer, conceptIndexorIndexes); err != nil {
+		return err
+	}
+	if err := DefineIndexes(prefixer.TestConductorPrefixer, metadataIndexes); err != nil {
 		return err
 	}
 	return DefineViews(GlobalDB, globalViews)

--- a/pkg/dispers/metadata/metadata.go
+++ b/pkg/dispers/metadata/metadata.go
@@ -1,0 +1,135 @@
+package dispers
+
+import (
+	"errors"
+	"net/url"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
+)
+
+// Only the Conductor should save metadata
+var prefixC = prefixer.ConductorPrefixer
+
+type TaskMetadata struct {
+	Start time.Time `json:"start,omitempty"`
+	End   time.Time `json:"end,omitempty"`
+	URL   url.URL   `json:"url,omitempty"`
+	Error error     `json:"error,omitempty"`
+}
+
+// NewTaskMetadata returns a new TaskMetadata object
+func NewTaskMetadata() (TaskMetadata, error) {
+	now := time.Now()
+	doc := TaskMetadata{
+		Start: now,
+	}
+
+	return doc, nil
+}
+
+// Save the ExecutionMetadata in Conductor's database
+func (t *TaskMetadata) EndTask(err error) {
+	t.End = time.Now()
+	t.Error = err
+}
+
+// ExecutionMetadata are written on the conductor's database. The querier can read those ExecutionMetadata to know his query's state
+type ExecutionMetadata struct {
+	ExecutionMetadataID  string                  `json:"_id,omitempty"`
+	ExecutionMetadataRev string                  `json:"_rev,omitempty"`
+	QueryID              string                  `json:"query,omitempty"`
+	Start                time.Time               `json:"start,omitempty"`
+	End                  time.Time               `json:"end,omitempty"`
+	Process              string                  `json:"process,omitempty"`
+	Host                 url.URL                 `json:"host,omitempty"`
+	Tasks                map[string]TaskMetadata `json:"tasks,omitempty"`
+}
+
+func (t *ExecutionMetadata) ID() string {
+	return t.ExecutionMetadataID
+}
+
+func (t *ExecutionMetadata) Rev() string {
+	return t.ExecutionMetadataRev
+}
+
+func (t *ExecutionMetadata) DocType() string {
+	return "io.cozy.execution.metadata"
+}
+
+func (t *ExecutionMetadata) Clone() couchdb.Doc {
+	cloned := *t
+	return &cloned
+}
+
+func (t *ExecutionMetadata) SetID(id string) {
+	t.ExecutionMetadataID = id
+}
+
+func (t *ExecutionMetadata) SetRev(rev string) {
+	t.ExecutionMetadataRev = rev
+}
+
+// NewExecutionMetadata returns a new ExecutionMetadata object
+func NewExecutionMetadata(process string, queryid string, host url.URL) (ExecutionMetadata, error) {
+	now := time.Now()
+	doc := ExecutionMetadata{
+		Start:   now,
+		Process: process,
+		QueryID: queryid,
+		Host:    host,
+		Tasks:   make(map[string]TaskMetadata),
+	}
+
+	err := couchdb.CreateDoc(prefixC, &doc)
+
+	return doc, err
+}
+
+// Save the ExecutionMetadata in Conductor's database
+func (m *ExecutionMetadata) SetTask(name string, task TaskMetadata) error {
+	if m.Tasks == nil {
+		tasks := make(map[string]TaskMetadata)
+		tasks[name] = task
+		m.Tasks = tasks
+	} else {
+		m.Tasks[name] = task
+	}
+	return couchdb.UpdateDoc(prefixC, m)
+}
+
+// EndExecution the ExecutionMetadata in Conductor's database
+func (m *ExecutionMetadata) EndExecution(err error) error {
+	m.End = time.Now()
+	return couchdb.UpdateDoc(prefixC, m)
+}
+
+// RetrieveExecutionMetadata get ExecutionMetadata from a ExecutionMetadata in CouchDB
+func RetrieveExecutionMetadata(queryid string) (ExecutionMetadata, error) {
+
+	var out []ExecutionMetadata
+
+	err := couchdb.EnsureDBExist(prefixC, "io.cozy.execution.metadata")
+	if err != nil {
+		return ExecutionMetadata{}, err
+	}
+
+	req := &couchdb.FindRequest{Selector: mango.Equal("query", queryid)}
+	err = couchdb.FindDocs(prefixC, "io.cozy.execution.metadata", req, &out)
+	if err != nil {
+		return ExecutionMetadata{}, err
+	}
+
+	if len(out) == 0 {
+		return ExecutionMetadata{}, errors.New("No ExecutionMetadata for this query")
+	}
+
+	if len(out) > 1 {
+		return ExecutionMetadata{}, errors.New("Too many ExecutionMetadata for this query")
+	}
+
+	return out[0], nil
+}

--- a/pkg/dispers/metadata/metadata_test.go
+++ b/pkg/dispers/metadata/metadata_test.go
@@ -1,0 +1,85 @@
+package dispers
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/cozy/checkup"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/prefixer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecutionMetadata(t *testing.T) {
+
+	_, err := RetrieveExecutionMetadata("mean")
+	assert.Error(t, err)
+
+	// Let's Create A ExecutionMetadata
+	meta, err := NewExecutionMetadata("subscribe", "Cozy-DISPERS", url.URL{Scheme: "http"})
+	assert.NoError(t, err)
+
+	// Let's Create Task For The ExecutionMetadata
+	task, err := NewTaskMetadata()
+	assert.NoError(t, err)
+	err = meta.SetTask("Hope It Will Not Crash", task)
+	assert.NoError(t, err)
+
+	err = meta.EndExecution(errors.New("Oh nooooo!"))
+	assert.NoError(t, err)
+
+	// Let's Create A ExecutionMetadata
+	meta, err = NewExecutionMetadata("query", "mean", url.URL{Scheme: "http"})
+	assert.NoError(t, err)
+
+	meta2, err := RetrieveExecutionMetadata("mean")
+	assert.Equal(t, meta.ID(), meta2.ID())
+	assert.Equal(t, meta.Rev(), meta2.Rev())
+	assert.NoError(t, err)
+
+	// Let's Create Task For The ExecutionMetadata
+	task, err = NewTaskMetadata()
+	assert.NoError(t, err)
+	err = meta2.SetTask("Concept Indexor", task)
+	assert.NoError(t, err)
+	assert.Equal(t, true, task.Start.Equal(meta2.Tasks["Concept Indexor"].Start))
+
+	// Let's Create Task For The ExecutionMetadata
+	task, err = NewTaskMetadata()
+	assert.NoError(t, err)
+	err = meta2.SetTask("Target Finder", task)
+	assert.NoError(t, err)
+	assert.Equal(t, true, task.Start.Equal(meta2.Tasks["Target Finder"].Start))
+
+	err = meta2.EndExecution(nil)
+	assert.NoError(t, err)
+}
+
+func TestMain(m *testing.M) {
+	config.UseTestFile()
+
+	prefixC = prefixer.TestConductorPrefixer
+
+	// First we make sure couchdb is started
+	db, err := checkup.HTTPChecker{URL: config.CouchURL().String()}.Check()
+	if err != nil || db.Status() != checkup.Healthy {
+		fmt.Println("This test need couchdb to run.")
+		os.Exit(1)
+	}
+
+	err = couchdb.ResetDB(prefixC, "io.cozy.execution.metadata")
+	if err != nil {
+		fmt.Printf("Cant reset db (%s, %s) %s\n", prefixC, "io.cozy.execution.metadata", err.Error())
+		os.Exit(1)
+	}
+
+	couchdb.InitGlobalTestDB()
+
+	res := m.Run()
+	os.Exit(res)
+
+}

--- a/pkg/prefixer/prefixer.go
+++ b/pkg/prefixer/prefixer.go
@@ -39,6 +39,9 @@ var GlobalPrefixer = NewPrefixer("", "global")
 // ConductorPrefixer returns a Conductor prefixer with the wildcard '*' as prefix.
 var ConductorPrefixer = NewPrefixer("", "conductor")
 
+// TestConductorPrefixer returns a TestConductor prefixer with the wildcard '*' as prefix.
+var TestConductorPrefixer = NewPrefixer("", "testconductor")
+
 // ConceptIndexorPrefixer returns a Concept Indexor prefixer with the wildcard '*' as prefix.
 var ConceptIndexorPrefixer = NewPrefixer("", "conceptindexor")
 

--- a/web/dispers/dispers.go
+++ b/web/dispers/dispers.go
@@ -3,11 +3,9 @@ package dispers
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	"github.com/cozy/cozy-stack/pkg/dispers"
 	"github.com/cozy/cozy-stack/pkg/dispers/dispers"
-	"github.com/cozy/cozy-stack/pkg/metadata"
 	"github.com/cozy/echo"
 )
 
@@ -29,20 +27,15 @@ func createConcept(c echo.Context) error {
 
 	// Create array of hashes
 	hashes := make([]string, len(in.EncryptedConcepts))
-	var sliceOfMeta []metadata.Metadata
 	for index, element := range in.EncryptedConcepts {
-		meta := metadata.NewMetadata("Hash concept", strings.Join([]string{in.EncryptedConcepts, in.Concepts}, ""), []string{"CI", "Concept"})
 		out, err := enclave.CreateConcept(element)
 		if err != nil {
 			return err
 		}
-		meta.Close(out, err)
 		hashes[index] = out
-		sliceOfMeta = append(sliceOfMeta, meta)
 	}
 	return c.JSON(http.StatusOK, dispers.OutputCI{
-		Hashes:            hashes,
-		metadata.Metadata: sliceOfMeta,
+		Hashes: hashes,
 	})
 }
 
@@ -78,9 +71,8 @@ func selectAddresses(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, dispers.OutputTF{
 		ListOfAddresses: finallist,
-    })
+	})
 }
-  
 
 // Routes sets the routing for the dispers service
 func Routes(router *echo.Group) {


### PR DESCRIPTION
Metadata provides a way to follow the request from end to end. Metadata are created by every actor of the request (CI, TF, T, DA, Stack, ...) and are given to the conductor. Thanks to a method, the conductor can easily saved the metadata in its database.

Metadata provides information about the request. Its needs to be used outside of the package "enclave" :

    Time of treatment's begining / ending and duration
    Host / Actor
    Name / Description of the treatements

Metadata has got one function and 2 methods :

    NewMetadata to instanciate a new metadata
    .Close() to close the metadata
    .Push() to save it in Conductor's database

Metadata are saved in a dedicated database with the doctype io.cozy.metadata. This database contains one document for each request.